### PR TITLE
add docker-in-docker so we can run megalinter inside a devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,6 +76,9 @@
 		},
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {
+			"version": "latest"
 		}
 	}
 }


### PR DESCRIPTION
# Description

Add the docker runtime to the devcontainer so we can run containers are part of the loal development toolchain.  This enables running mega-linter without individual devs having to modify their systems.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# What components are impacted?

the DevContainer
- 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `$ npx mega-linter-runner` inside a devContainer runs to completion


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK: docker-in-docker v1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- N/A I have commented my code, particularly in hard-to-understand areas
- N/A I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- N/AI have added tests that prove my fix is effective or that my feature works
- N/A New and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
